### PR TITLE
Add the packaging metadata to build the pocketplace snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: pocketplace
+version: master
+summary: Draw pixels on a canvas with friends.
+description: |
+  Draw pixels on a canvas with friends.
+
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  pocketplace:
+    command: pocketplace
+    plugs: [network, network-bind]
+
+parts:
+  pocketplace:
+    source: .
+    plugin: go
+    go-importpath: github.com/olahol/pocketplace


### PR DESCRIPTION
This package will let you publish the latest pocketplace in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.